### PR TITLE
add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git/
+.vscode/
+Dockerfile
+node_modules/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM node:14-alpine as builder
+
+WORKDIR /app
+RUN yarn global add @quasar/cli
+
+COPY package.json package-lock.json yarn.lock ./
+RUN yarn install
+
+COPY . .
+ENV PUBLIC_PATH /
+RUN quasar build
+
+
+FROM caddy:2-alpine
+
+WORKDIR /srv
+COPY --from=builder /app/dist/spa/ ./
+
+EXPOSE 80
+CMD ["caddy", "file-server"]

--- a/quasar.conf.js
+++ b/quasar.conf.js
@@ -55,7 +55,7 @@ module.exports = configure(function (ctx) {
     // Full list of options: https://v2.quasar.dev/quasar-cli/quasar-conf-js#Property%3A-build
     build: {
       vueRouterMode: 'hash', // available values: 'hash', 'history'
-      publicPath: process.env.NODE_ENV === 'development' ? '/' : '/typesense-dashboard',
+      publicPath: process.env.PUBLIC_PATH ?? process.env.NODE_ENV === 'development' ? '/' : '/typesense-dashboard',
       // transpile: false,
 
       // Add dependencies for transpiling with Babel (Array of string/regex)


### PR DESCRIPTION
Hi! :)
This PR adds a fairly basic Dockerfile that allows one to self-host this dashboard with ease using Docker.

It may also be used as an alternative to electron, though it obviously comes with the downsides mentioned in [README.md#desktop](https://github.com/bfritscher/typesense-dashboard/blob/75acd7acfee47abe9f6bac758dd164ca68eb7218/README.md#desktop).
 
Example usage:
```bash
$ docker build -t typesense-dashboard .
$ docker run -d -p 80:80 typesense-dashboard
```

`caddy` is used for serving the actual files.
One could also copy `/srv` from the final Docker Image into another:
```Dockerfile
FROM alpine
COPY --from=typesense-dashboard /srv /typesense-dashboard
```

I did modify `publicPath` in `quasar.conf.js` to allow overwriting the public path via `PUBLIC_PATH` if needed, while preserving the old behavior.
Used in Dockerfile#L10

@IndeedNotJames