### PR TITLE
fix: docker public path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY package.json yarn.lock ./
 RUN yarn install
 
 COPY . .
-ENV PUBLIC_PATH /
+ARG PUBLIC_PATH /
 RUN quasar build
 
 

--- a/quasar.conf.js
+++ b/quasar.conf.js
@@ -55,7 +55,7 @@ module.exports = configure(function (ctx) {
     // Full list of options: https://v2.quasar.dev/quasar-cli/quasar-conf-js#Property%3A-build
     build: {
       vueRouterMode: 'hash', // available values: 'hash', 'history'
-      publicPath: process.env.PUBLIC_PATH ?? process.env.NODE_ENV === 'development' ? '/' : '/typesense-dashboard',
+      publicPath: process.env.PUBLIC_PATH ?? (process.env.NODE_ENV === 'development' ? '/' : '/typesense-dashboard'),
       // transpile: false,
 
       // Add dependencies for transpiling with Babel (Array of string/regex)


### PR DESCRIPTION
This PR makes two small changes to how the public path build arg is handled in the existing docker setup:

- Change ENV to ARG; this allows setting this value more easily using `--build-arg=PUBLIC_PATH=/example` during the build process which is not possible in case of ENV statements
- Fix the evaluation order in the quasar.conf.js; `'/foo' ?? true ? '/' : '/typesense-dashboard'` evaluates to `'/'` instead of `'/foo`. Putting parenthesis around that ensures that if `process.env.PUBLIC_PATH` is present, its value is used