### PR TITLE
FIX PULBIC_PATH not set correctly in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY package.json yarn.lock ./
 RUN yarn install
 
 COPY . .
-ARG PUBLIC_PATH /
+ARG PUBLIC_PATH=/
 RUN quasar build
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
+ARG PUBLIC_PATH=/
 FROM node:18-alpine as builder
-
+ARG PUBLIC_PATH
 WORKDIR /app
 RUN yarn global add @quasar/cli
 
@@ -7,14 +8,14 @@ COPY package.json yarn.lock ./
 RUN yarn install
 
 COPY . .
-ARG PUBLIC_PATH=/
+
 RUN quasar build
 
 
 FROM caddy:2-alpine
-
+ARG PUBLIC_PATH
 WORKDIR /srv
-COPY --from=builder /app/dist/spa/ ./
+COPY --from=builder /app/dist/spa/ .${PUBLIC_PATH}
 
 EXPOSE 80
 CMD ["caddy", "file-server"]

--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ FROM alpine
 COPY --from=typesense-dashboard /srv /typesense-dashboard
 ```
 
+To build and serve from a subfolder `/example` (must start with /)
+
+```bash
+docker build --build-arg=PUBLIC_PATH=/example -t typesense-dashboard .
+```
+
 ### Desktop
 
 With the desktop application everything except instant search will work without cors.


### PR DESCRIPTION
PUBLIC_PATH was unset, due to a missing `=` which caused the docker container to use /typsense-dashboard as the PUBLIC_PATH instead of root, breaking all javascript and css includes in index.html.

The bug was introduced in #10 