### PR TITLE
:bug: Dockerfile fails to build on macOS M1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,10 @@ ARG PUBLIC_PATH=/
 FROM node:18-alpine as builder
 ARG PUBLIC_PATH
 WORKDIR /app
+
+RUN apk add --no-cache --virtual .gyp \
+        g++ make py3-pip
+
 RUN yarn global add @quasar/cli
 
 COPY package.json yarn.lock ./
@@ -11,6 +15,7 @@ COPY . .
 
 RUN quasar build
 
+RUN apk del .gyp
 
 FROM caddy:2-alpine
 ARG PUBLIC_PATH


### PR DESCRIPTION
Signed-off-by: musaid <musaid@live.com>

Fixes the docker build issues on macOS m1.


## Error
```
 > [builder 5/7] RUN yarn install:
#12 0.254 yarn install v1.22.19
#12 0.306 [1/5] Validating package.json...
#12 0.310 [2/5] Resolving packages...
#12 0.535 [3/5] Fetching packages...
#12 34.11 [4/5] Linking dependencies...
#12 34.11 warning " > monaco-editor-webpack-plugin@7.0.1" has unmet peer dependency "webpack@^4.5.0 || 5.x".
#12 34.11 warning " > vue-instantsearch@4.6.0" has unmet peer dependency "algoliasearch@>= 3.32.0 < 5".
#12 34.11 warning "vue-instantsearch > instantsearch.js@4.48.1" has unmet peer dependency "algoliasearch@>= 3.1 < 6".
#12 34.11 warning "vue-instantsearch > instantsearch.js > algoliasearch-helper@3.11.1" has unmet peer dependency "algoliasearch@>= 3.1 < 6".
#12 34.11 warning " > @babel/eslint-parser@7.19.1" has unmet peer dependency "@babel/core@>=7.11.0".
#12 34.11 warning "@typescript-eslint/eslint-plugin > tsutils@3.21.0" has unmet peer dependency "typescript@>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta".
#12 40.28 [5/5] Building fresh packages...
#12 41.21 error /app/node_modules/utf-8-validate: Command failed.
#12 41.21 Exit code: 1
#12 41.21 Command: node-gyp-build
#12 41.21 Arguments:
#12 41.21 Directory: /app/node_modules/utf-8-validate
#12 41.21 Output:
#12 41.21 gyp info it worked if it ends with ok
#12 41.21 gyp info using node-gyp@9.1.0
#12 41.21 gyp info using node@18.12.0 | linux | arm64
#12 41.21 gyp ERR! find Python
#12 41.21 gyp ERR! find Python Python is not set from command line or npm configuration
#12 41.21 gyp ERR! find Python Python is not set from environment variable PYTHON
#12 41.21 gyp ERR! find Python checking if "python3" can be used
#12 41.21 gyp ERR! find Python - "python3" is not in PATH or produced an error
#12 41.21 gyp ERR! find Python checking if "python" can be used
#12 41.21 gyp ERR! find Python - "python" is not in PATH or produced an error
#12 41.21 gyp ERR! find Python
#12 41.21 gyp ERR! find Python **********************************************************
#12 41.21 gyp ERR! find Python You need to install the latest version of Python.
#12 41.21 gyp ERR! find Python Node-gyp should be able to find and use Python. If not,
#12 41.21 gyp ERR! find Python you can try one of the following options:
#12 41.21 gyp ERR! find Python - Use the switch --python="/path/to/pythonexecutable"
#12 41.21 gyp ERR! find Python   (accepted by both node-gyp and npm)
#12 41.21 gyp ERR! find Python - Set the environment variable PYTHON
#12 41.21 gyp ERR! find Python - Set the npm configuration variable python:
#12 41.21 gyp ERR! find Python   npm config set python "/path/to/pythonexecutable"
#12 41.21 gyp ERR! find Python For more information consult the documentation at:
#12 41.21 gyp ERR! find Python https://github.com/nodejs/node-gyp#installation
#12 41.21 gyp ERR! find Python **********************************************************
#12 41.21 gyp ERR! find Python
#12 41.21 gyp ERR! configure error
#12 41.21 gyp ERR! stack Error: Could not find any Python installation to use
#12 41.21 gyp ERR! stack     at PythonFinder.fail (/usr/local/lib/node_modules/npm/node_modules/node-gyp/lib/find-python.js:330:47)
#12 41.21 gyp ERR! stack     at PythonFinder.runChecks (/usr/local/lib/node_modules/npm/node_modules/node-gyp/lib/find-python.js:159:21)
#12 41.21 gyp ERR! stack     at PythonFinder.<anonymous> (/usr/local/lib/node_modules/npm/node_modules/node-gyp/lib/find-python.js:202:16)
#12 41.21 gyp ERR! stack     at PythonFinder.execFileCallback (/usr/local/lib/node_modules/npm/node_modules/node-gyp/lib/find-python.js:294:16)
#12 41.21 gyp ERR! stack     at exithandler (node:child_process:420:5)
#12 41.21 gyp ERR! stack     at ChildProcess.errorhandler (node:child_process:432:5)
#12 41.21 gyp ERR! stack     at ChildProcess.emit (node:events:513:28)
#12 41.21 gyp ERR! stack     at ChildProcess._handle.onexit (node:internal/child_process:289:12)
#12 41.21 gyp ERR! stack     at onErrorNT (node:internal/child_process:476:16)
#12 41.21 gyp ERR! stack     at process.processTicksAndRejections (node:internal/process/task_queues:82:21)
#12 41.21 gyp ERR! System Linux 5.10.124-linuxkit
#12 41.21 gyp ERR! command "/usr/local/bin/node" "/usr/local/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
#12 41.21 gyp ERR! cwd /app/node_modules/utf-8-validate
#12 41.21 gyp ERR! node -v v18.12.0
#12 41.21 gyp ERR! node-gyp -v v9.1.0
#12 41.21 gyp ERR! not ok
```