### PR TITLE
feat: add kustomize to use along typesense/typesense-kubernetes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ As a web application, only typesense server started with `--enable-cors` will wo
 Use https://bfritscher.github.io/typesense-dashboard/ or build and install on your own server
 
 #### Limitation
-When using in your browser from an https adresse your server must also be behind SSL. Or you will get a MixedContent Network Error. (You might allow mix content in your browser, but this is not recommended).
+When using in your browser from an https address your server must also be behind SSL. Or you will get a MixedContent Network Error. (You might allow mix content in your browser, but this is not recommended).
 
 
 #### Docker
@@ -63,7 +63,38 @@ Sample config.json (same data as saved in localStorage of the browser).
     "tls":true
   }
 }
-````
+```
+
+#### Kustomize
+
+To use along [Kustomize deployment for Typesense](https://github.com/typesense/typesense-kubernetes)
+
+Example usage [here](kustomize/overlays/dev)
+
+Create `config.json` file with your configuration and API key.
+
+Create kustomization file.
+```yml
+resources:
+- github.com/typesense/typesense-kubernetes/base
+- github.com/bfritscher/typesense-dashboard/kustomize/base
+
+namespace: typesense
+
+images:
+- name: typesense-dashboard
+  newName: typesense-dashboard
+  newTag: latest
+
+secretGenerator:
+- files:
+  - config.json
+  name: typesense-dashboard-config
+  behavior: replace
+  options:
+    disableNameSuffixHash: true
+  type: Opaque
+```
 
 
 ### Desktop

--- a/kustomize/base/config.json
+++ b/kustomize/base/config.json
@@ -1,0 +1,10 @@
+{
+    "apiKey": "xyz",
+    "node": {
+      "host":"somehost",
+      "port":"443",
+      "protocol":"https",
+      "path":"",
+      "tls":true
+    }
+}

--- a/kustomize/base/install.yaml
+++ b/kustomize/base/install.yaml
@@ -1,0 +1,50 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: typesense-dashboard-service
+  namespace: typesense
+spec:
+  selector:
+    app: typesense-dashboard
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80
+  type: ClusterIP
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: typesense-dashboard-deployment
+  namespace: typesense
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: typesense-dashboard
+  template:
+    metadata:
+      labels:
+        app: typesense-dashboard
+    spec:
+      containers:
+      - name: typesense-dashboard-container
+        image: typesense-dashboard
+        ports:
+        - containerPort: 80
+        resources:
+          requests:
+            memory: "128Mi"
+            cpu: "50m"
+          limits:
+            memory: "128Mi"
+            cpu: "50m"
+        volumeMounts:
+        - name: config-volume
+          mountPath: /srv/config.json
+          subPath: config.json
+      volumes:
+      - name: config-volume
+        secret:
+          secretName: typesense-dashboard-config

--- a/kustomize/base/kustomization.yaml
+++ b/kustomize/base/kustomization.yaml
@@ -1,0 +1,10 @@
+resources:
+- install.yaml
+
+secretGenerator:
+- files:
+  - config.json
+  name: typesense-dashboard-config
+  options:
+    disableNameSuffixHash: true
+  type: Opaque

--- a/kustomize/overlays/dev/config.json
+++ b/kustomize/overlays/dev/config.json
@@ -1,0 +1,10 @@
+{
+    "apiKey": "my-api-key",
+    "node": {
+      "host":"somehost",
+      "port":"443",
+      "protocol":"http",
+      "path":"",
+      "tls":false
+    }
+}

--- a/kustomize/overlays/dev/kustomization.yaml
+++ b/kustomize/overlays/dev/kustomization.yaml
@@ -1,0 +1,19 @@
+resources:
+- ../../base
+# - github.com/bfritscher/typesense-dashboard/kustomize/base
+
+namespace: typesense
+
+images:
+- name: typesense-dashboard
+  newName: typesense-dashboard
+  newTag: latest
+
+secretGenerator:
+- files:
+  - config.json
+  name: typesense-dashboard-config
+  behavior: replace
+  options:
+    disableNameSuffixHash: true
+  type: Opaque


### PR DESCRIPTION
Hey there :wave: ,

I am using kustomize to deploy typesense as specified [in this repo](https://github.com/typesense/typesense-kubernetes/tree/master). I wanted to deploy this cool dashboard along my typesense deployment to kubernetes and this is the result.

Right now I have a kustomization file like this
```
resources:
- github.com/typesense/typesense-kubernetes/base
- github.com/thecodemustgrow/typesense-dashboard/kustomize/base?ref=feature/kustomize
```