### PR TITLE
minor fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "author": "Boris Fritscher <boris@fritscher.ch>",
   "private": true,
   "scripts": {
+    "start": "quasar dev",
+    "start:desktop": "quasar dev -m electron --devtools",
+    "build": "quasar build",
+    "build:desktop": "quasar build --mode electron --target all",
     "lint": "eslint --ext .js,.ts,.vue ./",
     "test": "echo \"No test specified\" && exit 0"
   },

--- a/src/pages/AnalyticsRules.vue
+++ b/src/pages/AnalyticsRules.vue
@@ -146,7 +146,7 @@ export default defineComponent({
   data() {
     return {
       rule: initialData(),
-      expanded: this.$store.state.node.data.aliases.length === 0,
+      expanded: this.$store.state.node.data.analyticsRules.length === 0,
       filter: '',
       columns: [
         {

--- a/src/store/node/actions.ts
+++ b/src/store/node/actions.ts
@@ -36,6 +36,9 @@ const actions: ActionTree<NodeStateInterface, StateInterface> = {
             context.dispatch('getAliases'),
             context.dispatch('getApiKeys'),
             context.dispatch('getDebug'),
+            context.dispatch('getSearchPresets'),
+            context.dispatch('getAnalyticsRules'),
+            context.dispatch('getStopwords'),
           ]);
           context.commit('setIsConnected', true);
           context.commit('saveHistory');
@@ -517,7 +520,7 @@ const actions: ActionTree<NodeStateInterface, StateInterface> = {
     } catch (error) {
       context.commit('setError', (error as Error).message);
     }
-  },  
+  },
 };
 
 export default actions;


### PR DESCRIPTION
- AnalyticsRules page calculated `expanded` field from wrong data section
- `expanded` can't be computed for pages SearchPresets, AnalyticsRules, Stopwords on first application load
- start/build scripts in package.json, a more common method rather than direct quasar commands