### PR TITLE
feat: stopwords during search disabled if not available

### DIFF
--- a/src/components/search/SearchInstantSearch.vue
+++ b/src/components/search/SearchInstantSearch.vue
@@ -29,6 +29,7 @@
         <q-select
           v-model="currentStopwordsSet"
           @update:model-value="updateTypesenseAdapterConfiguration()"
+          :disable="!$store.state.node.data.features.stopwords"
           outlined
           clearable
           dense


### PR DESCRIPTION
Stopwords select on search page is now disabled if this feature is not available.

p.s.: Hm... Or is an empty list enough? There was a misunderstanding with a blocked menu item.
p.p.s: What about title attr (on every blocked feature) in this case with hint "This feature available since v.26"? Or is this too much?