### PR TITLE
feat: debounced search

### DIFF
--- a/src/components/search/DebouncedSearchBox.vue
+++ b/src/components/search/DebouncedSearchBox.vue
@@ -1,0 +1,66 @@
+<template>
+  <q-input
+    v-model="query"
+    @clear="clear"
+    dense
+    autofocus
+    outlined
+    type="search"
+    clearable
+    clear-icon="close"
+    placeholder="Search...">
+    <template v-slot:prepend>
+      <q-icon name="search" />
+    </template>
+  </q-input>
+
+</template>
+
+<script>
+
+import { connectSearchBox } from 'instantsearch.js/es/connectors';
+import { createWidgetMixin } from 'vue-instantsearch/vue3/es';
+
+export default {
+  mixins: [createWidgetMixin({ connector: connectSearchBox })],
+  props: {
+    delay: {
+      type: Number,
+      default: 400,
+      required: false,
+    },
+  },
+  data() {
+    return {
+      timerId: null,
+      localQuery: '',
+    };
+  },
+  unmounted() {
+    if (this.timerId) {
+      clearTimeout(this.timerId);
+    }
+  },
+  methods: {
+    clear() {
+      this.query = '';
+    }
+  },
+  computed: {
+    query: {
+      get() {
+        return this.localQuery;
+      },
+      set(val) {
+        this.localQuery = val;
+        if (this.timerId) {
+          clearTimeout(this.timerId);
+        }
+        this.timerId = setTimeout(() => {
+          this.state.refine(this.localQuery);
+        }, this.delay);
+      },
+    },
+  },
+};
+</script>

--- a/src/components/search/DebouncedSearchBox.vue
+++ b/src/components/search/DebouncedSearchBox.vue
@@ -26,7 +26,7 @@ export default {
   props: {
     delay: {
       type: Number,
-      default: 400,
+      default: 200,
       required: false,
     },
   },

--- a/src/components/search/SearchInstantSearch.vue
+++ b/src/components/search/SearchInstantSearch.vue
@@ -6,7 +6,9 @@
     :middlewares="middlewares"
   >
     <ais-configure :hits-per-page.camel="12" />
-    <ais-search-box placeholder="" />
+    <ais-search-box index-name="instant_search" :search-client="searchClient">
+      <debounced-search-box />
+    </ais-search-box>
     <ais-stats></ais-stats>
     <ais-current-refinements />
 
@@ -70,12 +72,13 @@
 
 <script lang="ts">
 import SearchResultItem from 'src/components/search/SearchResultItem.vue';
+import DebouncedSearchBox from 'src/components/search/DebouncedSearchBox.vue';
 import TypesenseInstantSearchAdapter from 'typesense-instantsearch-adapter';
 import { CollectionSchema } from 'typesense/lib/Typesense/Collection';
 import { defineComponent } from 'vue';
 
 export default defineComponent({
-  components: { SearchResultItem },
+  components: { SearchResultItem, DebouncedSearchBox },
   name: 'SearchInstantSearch',
   data() {
     const data = {


### PR DESCRIPTION
Debounced searchbox on search page. Implementation taken from [algolia site](https://www.algolia.com/doc/guides/building-search-ui/going-further/improve-performance/vue/?client=Vue+3#debouncing).

Now typing «redis» only one search will be performed instead of five in a row.