### PR TITLE
Show CPU stats in ascending order

### DIFF
--- a/src/pages/ServerStatus.vue
+++ b/src/pages/ServerStatus.vue
@@ -9,16 +9,14 @@
             <div class="row">
               <div
                 class="column flex-center flex-wrap q-ma-md"
-                v-for="metric in Object.keys(
-                  $store.state.node.data.metrics
-                ).filter((m) => m.includes('cpu'))"
-                :key="metric"
+                v-for="cpu in sortedCPU"
+                :key="cpu.node"
               >
-                <span class="text-overline">{{ metric.split('_')[1] }}</span>
+                <span class="text-overline">CPU {{ cpu.node }}</span>
                 <q-circular-progress
                   show-value
                   class="text-accent"
-                  :value="parseFloat($store.state.node.data.metrics[metric])"
+                  :value="cpu.value"
                   size="50px"
                   color="accent"
                   track-color="grey-3"
@@ -266,6 +264,16 @@ export default defineComponent({
     this.refreshInterval = window.setInterval(() => {
       void this.$store.dispatch('node/refreshServerStatus');
     }, 2000);
+  },
+  computed: {
+    sortedCPU() {
+      return Object.entries(this.$store.state.node.data.metrics)
+        .filter(([key]) => key.includes('cpu'))
+        .map(([key, value]) => {
+          return { node: parseInt(key.split('_')[1].replace('cpu', ''))  || 0, value: parseFloat(<string>value) }
+        })
+        .sort((a, b) => a.node - b.node)
+    }
   },
   methods: {
     prettyBytes,


### PR DESCRIPTION

![2024-04-24_11-09-39](https://github.com/bfritscher/typesense-dashboard/assets/360727/1a71238f-d30e-49d3-98a7-faff85c6b054)


Use a computed function to sort the CPU stats on the CPU node number. Returns an array like:

[
  { node: 0, value: 20 },  { node: 1, value: 0 },
  { node: 2, value: 0 },   { node: 3, value: 0 },
  { node: 4, value: 0 },   { node: 5, value: 0 },
  { node: 6, value: 0 },   { node: 7, value: 0 },
  { node: 8, value: 0 },   { node: 9, value: 0 },
  { node: 10, value: 10 }, { node: 11, value: 0 },
  { node: 12, value: 0 },  { node: 13, value: 0 },
  { node: 14, value: 0 },  { node: 15, value: 0 },
  { node: 16, value: 0 },  { node: 17, value: 0 },
  { node: 18, value: 0 },  { node: 19, value: 0 },
  { node: 20, value: 0 },  { node: 21, value: 0 },
  { node: 22, value: 0 },  { node: 23, value: 0 },
  { node: 24, value: 0 },  { node: 25, value: 0 },
  { node: 26, value: 0 },  { node: 27, value: 0 },
  { node: 28, value: 0 },  { node: 29, value: 0 },
  { node: 30, value: 0 },  { node: 31, value: 0 },
  { node: 32, value: 0 }
]