### PR TITLE
Dark theme colors

### DIFF
--- a/src/css/quasar.variables.scss
+++ b/src/css/quasar.variables.scss
@@ -31,3 +31,15 @@ $warning   : #fba918;
     }
   }
 }
+
+.body--dark {
+  .q-radio__inner,
+  .q-tab--active .q-tab__label,
+  .q-field--highlighted .q-field__label {
+    color: #fff !important;
+  }
+
+  .ais-Stats-text {
+    color: #ffffffcc !important;
+  }
+}

--- a/src/pages/ServerStatus.vue
+++ b/src/pages/ServerStatus.vue
@@ -15,7 +15,6 @@
                 <span class="text-overline">CPU {{ cpu.node }}</span>
                 <q-circular-progress
                   show-value
-                  class="text-accent"
                   :value="cpu.value"
                   size="50px"
                   color="accent"


### PR DESCRIPTION
Some fixes for dark theme colors:
- CPU load indicators
- All input labels
- Tab panel labels
- ais-stats

Motivation: customized `primary` color (#1f2937) almost invisible at dark background;