### PR TITLE
Fix styling of specific text on the search page in dark mode

### DIFF
--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -2,3 +2,7 @@
 .material-symbols-sharp {
   font-weight: 100;
 }
+
+.ais-RefinementList-labelText {
+  padding: 0 5px;
+}

--- a/src/css/quasar.variables.scss
+++ b/src/css/quasar.variables.scss
@@ -42,4 +42,8 @@ $warning: #fba918;
   .ais-Stats-text {
     color: #ffffffcc !important;
   }
+
+  .ais-Highlight {
+    color: #ffffffab !important;
+  }
 }

--- a/src/css/quasar.variables.scss
+++ b/src/css/quasar.variables.scss
@@ -39,11 +39,37 @@ $warning: #fba918;
     color: #fff !important;
   }
 
-  .ais-Stats-text {
-    color: #ffffffcc !important;
-  }
-
-  .ais-Highlight {
+  .ais-Breadcrumb,
+  .ais-ClearRefinements,
+  .ais-CurrentRefinements,
+  .ais-GeoSearch,
+  .ais-FrequentlyBoughtTogether,
+  .ais-HierarchicalMenu,
+  .ais-Hits,
+  .ais-Results,
+  .ais-HitsPerPage,
+  .ais-ResultsPerPage,
+  .ais-InfiniteHits,
+  .ais-InfiniteResults,
+  .ais-LookingSimilar,
+  .ais-Menu,
+  .ais-MenuSelect,
+  .ais-NumericMenu,
+  .ais-NumericSelector,
+  .ais-Pagination,
+  .ais-Panel,
+  .ais-PoweredBy,
+  .ais-RangeInput,
+  .ais-RangeSlider,
+  .ais-RatingMenu,
+  .ais-RefinementList,
+  .ais-RelatedProducts,
+  .ais-SearchBox,
+  .ais-RelevantSort,
+  .ais-SortBy,
+  .ais-Stats,
+  .ais-TrendingItems,
+  .ais-ToggleRefinement {
     color: #ffffffab !important;
   }
 }


### PR DESCRIPTION
Hi! This is a very useful project, thank you!

I made this change to fix how the category item text on the Search page was showing up in dark mode. Here's the before:

<img width="2048" alt="before" src="https://github.com/user-attachments/assets/654d9040-181a-4e1e-a20f-1f3bd0ec7820" />

and the after:

<img width="2048" alt="after" src="https://github.com/user-attachments/assets/67a08ff5-cb5d-4ad9-832b-0b0b1f43bcea" />
