### PR TITLE
feat(SearchResultItem): enhance display for nested elements

### DIFF
--- a/src/components/search/SearchResultItem.vue
+++ b/src/components/search/SearchResultItem.vue
@@ -20,8 +20,28 @@
               <div
                 v-for="(result, index) in item._highlightResult[field.name]"
                 :key="index"
-                v-html="result.value"
-              ></div>
+              >
+                <div v-if="!result.value">
+                  <div v-for="(_, propertyIndex) in item[field.name][index]" :key="propertyIndex">
+                    <div v-if="Array.isArray(item[field.name][index][propertyIndex])">
+                      <span
+                        v-for="(__, nestedIndex) in item[field.name][index][propertyIndex]"
+                        :key="nestedIndex"
+                      >
+                        <ais-highlight
+                          :hit="item"
+                          :attribute="field.name + '.' + index + '.' + propertyIndex+ '.' + nestedIndex"
+                        />
+                        <span v-if="nestedIndex < item[field.name][index][propertyIndex].length - 1">, </span>
+                      </span>
+                    </div>
+                    <div v-else>
+                      <ais-highlight :attribute="field.name+'.'+index+'.'+propertyIndex" :hit="item" />
+                    </div>
+                  </div>
+                </div>
+                <div v-else v-html="result.value" />
+              </div>
             </div>
             <div v-else>
               <div v-if="field.name.includes('.*')">


### PR DESCRIPTION
**Reason:** Currently the search result element only displays properties of a flat array, but in case of a nested object in an array it does not display anything at all.
**Suggestion:** Add support for arrays of objects (which can contain flat arrays).
**Limitations:** Only one level of recursion, for more it should be a separate component. But then the display becomes too confusing.

Example of element:
```json
[
  {
    "id": "d5d3adf6-b063-439a-8b43-a8d3c35b52d5",
    "name": "mr. anonymous",
    "knowledge": [
      {
        "context": "project analyst",
        "keywords": [
          "«UI constructor»",
          "UIC",
          "blocks library",
          "UX",
          "UI Kit"
        ]
      }
    ],
  }
]
```
<details>
  <summary>Collection schema</summary>
    
  ```json
{
  "name": "nested_schema",
  "fields": [
    {
      "name": "name",
      "type": "string",
      "facet": false,
      "optional": true,
      "index": true,
      "sort": true,
      "infix": false,
      "locale": "",
      "stem": true,
      "stem_dictionary": "",
      "store": true
    },
    {
      "name": "knowledge.context",
      "type": "string[]",
      "facet": false,
      "optional": true,
      "index": true,
      "sort": false,
      "infix": false,
      "locale": "",
      "stem": false,
      "stem_dictionary": "",
      "store": true
    },
    {
      "name": "knowledge.keywords",
      "type": "string[]",
      "facet": false,
      "optional": true,
      "index": true,
      "sort": false,
      "infix": false,
      "locale": "",
      "stem": false,
      "stem_dictionary": "",
      "store": true
    },
    {
      "name": "knowledge",
      "type": "object[]",
      "facet": false,
      "optional": true,
      "index": true,
      "sort": false,
      "infix": false,
      "locale": "",
      "stem": false,
      "stem_dictionary": "",
      "store": true
    }
  ],
  "default_sorting_field": "",
  "enable_nested_fields": true,
  "symbols_to_index": [],
  "token_separators": []
}
  ```
</details>

<details>
  <summary>Sreenshots</summary>
  Current behavior:

![image](https://github.com/user-attachments/assets/52562e42-0ee9-4fe1-ac9f-d9803c16c435)

New behavior (with highlight):
![image](https://github.com/user-attachments/assets/0dcd8331-4f6e-4edb-a210-25d495dbd7e0)  
</details>

