### PR TITLE
fix: scope for search result item attribute styles

### DIFF
--- a/src/components/search/SearchResultItemAttribute.vue
+++ b/src/components/search/SearchResultItemAttribute.vue
@@ -38,7 +38,7 @@ const isImage = (filename: string) => {
 };
 </script>
 
-<style>
+<style scoped>
 .ais-Highlight {
   display: block;
   text-overflow: ellipsis;


### PR DESCRIPTION
.ais-Highlight class for now applied everywhere and breaks displaying of `<ais-refinement-list/>`